### PR TITLE
recreate photos json file

### DIFF
--- a/bikemap/data/photos.js
+++ b/bikemap/data/photos.js
@@ -1,130 +1,1034 @@
 var photos = [
-	{file:"esp6rj5pzy3wpr0/2013-05-23%2012.54.48.jpg", dt:"Thursday, May 23, 12:54 PM", lat:32.756167, lon:-79.857167, note:"Shakedown ride."},
-	{file:"8tysnx5jxkxlm3e/2013-05-23%2013.07.12.jpg", dt:"Thursday, May 23, 1:07 PM", lat:32.758833, lon:-79.856667, note:""},
-	{file:"b47akn00q1j38oi/2013-05-23%2014.11.45.jpg", dt:"Thursday, May 23, 2:11 PM", lat:32.802500, lon:-79.912833, note:""},
-	{file:"5ubgzfkpkufyz8k/2013-05-24%2013.10.45.jpg", dt:"Friday, May 24, 1:10 PM", lat:32.890167, lon:-80.024333, note:""},
-	{file:"xzm7mlk42xwsko7/2013-05-24%2020.25.22.jpg", dt:"Friday, May 24, 8:25 PM", lat:32.790833, lon:-79.961500, note:"After our Build day on Thursday we went to go see a minor league Charleston Riverdogs game. Marcus led us all in cheering."},
-	{file:"6vwlt5f5unfcr3i/2013-05-25%2007.32.05.jpg", dt:"Saturday, May 25, 7:32 AM", lat:32.784833, lon:-79.933000, note:""},
-	{file:"lkgfkaq07d3yhq3/2013-05-25%2008.42.24.jpg", dt:"Saturday, May 25, 8:42 AM", lat:32.773000, lon:-79.927333, note:""},
-	{file:"anz9xjx1tc0fpde/2013-05-25%2011.08.11.jpg", dt:"Saturday, May 25, 11:08 AM", lat:32.972000, lon:-80.005000, note:""},
-	{file:"eafdm5hjidum9ny/2013-05-25%2012.37.21.jpg", dt:"Saturday, May 25, 12:37 PM", lat:33.059667, lon:-80.034667, note:""},
-	{file:"ux9yegyixahkxix/2013-05-25%2013.22.10.jpg", dt:"Saturday, May 25, 1:22 PM", lat:33.120333, lon:-80.018667, note:""},
-	{file:"x4f0um5nxs234hk/2013-05-25%2019.46.06.jpg", dt:"Saturday, May 25, 7:46 PM", lat:33.185667, lon:-80.000833, note:""},
-	{file:"m6ktbezppvzz7xl/2013-05-26%2007.46.23.jpg", dt:"Sunday, May 26, 7:46 AM", lat:33.225833, lon:-80.038833, note:""},
-	{file:"84a7w4pwlev0p8i/2013-05-26%2010.55.53.jpg", dt:"Sunday, May 26, 10:55 AM", lat:33.411500, lon:-79.981000, note:""},
-	{file:"evyexnom6fef1ft/2013-05-26%2011.41.59.jpg", dt:"Sunday, May 26, 11:41 AM", lat:33.438333, lon:-79.984667, note:""},
-	{file:"95cw9klnjywv53s/2013-05-26%2014.13.45.jpg", dt:"Sunday, May 26, 2:13 PM", lat:33.695333, lon:-80.210667, note:""},
-	{file:"6kc9oj8wa4mfjme/2013-05-27%2015.34.52.jpg", dt:"Monday, May 27, 3:34 PM", lat:33.893833, lon:-80.316667, note:""},
-	{file:"itfcmyqhlmi8bag/2013-05-28%2008.10.17.jpg", dt:"Tuesday, May 28, 8:10 AM", lat:33.917000, lon:-80.368833, note:""},
-	{file:"ehbhn3lu6mrz28q/2013-05-28%2020.38.29.jpg", dt:"Tuesday, May 28, 8:38 PM", lat:34.001167, lon:-81.033667, note:""},
-	{file:"76avcvd3377j7kx/2013-05-29%2008.57.16.jpg", dt:"Wednesday, May 29, 8:57 AM", lat:33.994833, lon:-81.055167, note:""},
-	{file:"mrd0j4dfni19566/2013-05-29%2010.20.31.jpg", dt:"Wednesday, May 29, 10:20 AM", lat:34.037500, lon:-81.218500, note:""},
-	{file:"j6gkdkq1mf3ryu4/2013-05-31%2020.12.37.jpg", dt:"Friday, May 31, 8:12 PM", lat:34.778333, lon:-82.266167, note:""},
-	{file:"u9gsshdle6gn7vq/2013-06-01%2010.33.50.jpg", dt:"Saturday, June 1, 10:33 AM", lat:34.641333, lon:-82.543500, note:""},
-	{file:"2eppykc27g11vhu/2013-06-03%2009.08.15.jpg", dt:"Monday, June 3, 9:08 AM", lat:34.000667, lon:-83.543833, note:""},
-	{file:"l2z911kxj8qioq7/2013-06-03%2009.51.42.jpg", dt:"Monday, June 3, 9:51 AM", lat:33.986833, lon:-83.682833, note:""},
-	{file:"gkifduuadqn37s2/2013-06-05%2010.31.28.jpg", dt:"Wednesday, June 5, 10:31 AM", lat:34.388500, lon:-85.620000, note:""},
-	{file:"fi45i665uuv0m27/2013-06-05%2010.35.01.jpg", dt:"Wednesday, June 5, 10:35 AM", lat:34.387833, lon:-85.620000, note:""},
-	{file:"i0tq59mrafpvolh/2013-06-05%2012.53.29.jpg", dt:"Wednesday, June 5, 12:53 PM", lat:34.495167, lon:-85.746833, note:""},
-	{file:"3bogzsu7eub65zh/2013-06-05%2013.02.45.jpg", dt:"Wednesday, June 5, 1:02 PM", lat:34.495000, lon:-85.747000, note:""},
-	{file:"p2lha23oojiotkx/2013-06-06%2010.32.14.jpg", dt:"Thursday, June 6, 10:32 AM", lat:34.564000, lon:-86.547500, note:""},
-	{file:"m5zmkl291k879cr/2013-06-11%2012.26.46.jpg", dt:"Tuesday, June 11, 12:26 PM", lat:34.278000, lon:-89.390500, note:""},
-	{file:"33mvo98z83ri41s/2013-06-11%2015.01.35.jpg", dt:"Tuesday, June 11, 3:01 PM", lat:34.370333, lon:-89.513333, note:""},
-	{file:"x0jbkmci2gb36p8/2013-06-12%2007.17.42.jpg", dt:"Wednesday, June 12, 7:17 AM", lat:34.364833, lon:-89.533833, note:""},
-	{file:"kg15hkfa2u2vtoy/2013-06-12%2014.15.22.jpg", dt:"Wednesday, June 12, 2:15 PM", lat:34.204667, lon:-90.506333, note:""},
-	{file:"li0jk1fw44v38hh/2013-06-13%2009.45.21.jpg", dt:"Thursday, June 13, 9:45 AM", lat:34.554667, lon:-90.662167, note:""},
-	{file:"gs9nn2vxqrbn0s7/2013-06-13%2019.08.30.jpg", dt:"Thursday, June 13, 7:08 PM", lat:34.479333, lon:-91.554500, note:""},
-	{file:"kjkjlk291z03qlf/2013-06-13%2019.45.34.jpg", dt:"Thursday, June 13, 7:45 PM", lat:34.476000, lon:-91.557667, note:""},
-	{file:"7mnd5k83k4l7ffw/2013-06-13%2019.45.37.jpg", dt:"Thursday, June 13, 7:45 PM", lat:34.476000, lon:-91.557833, note:""},
-	{file:"lv3xzq1ov2lmcky/2013-06-14%2020.12.52.jpg", dt:"Friday, June 14, 8:12 PM", lat:34.772167, lon:-92.300167, note:""},
-	{file:"jvax0dxlhaqqfn3/2013-06-16%2008.35.19.jpg", dt:"Sunday, June 16, 8:35 AM", lat:34.926333, lon:-92.563833, note:""},
-	{file:"wnx8h5twmrsdeu8/2013-06-16%2013.51.34.jpg", dt:"Sunday, June 16, 1:51 PM", lat:35.115000, lon:-92.951000, note:""},
-	{file:"a4h0w1bkb0uo6bw/2013-06-22%2009.25.17.jpg", dt:"Saturday, June 22, 9:25 AM", lat:35.683667, lon:-97.923667, note:""},
-	{file:"1nrqs0sg2xfvspt/2013-06-23%2009.42.09.jpg", dt:"Sunday, June 23, 9:42 AM", lat:36.144167, lon:-99.033167, note:""},
-	{file:"afipmqwpr5b7c8t/2013-06-23%2011.03.44.jpg", dt:"Sunday, June 23, 11:03 AM", lat:36.150000, lon:-99.297833, note:""},
-	{file:"rq84it54cghtzjk/2013-06-24%2006.16.53.jpg", dt:"Monday, June 24, 6:16 AM", lat:36.133667, lon:-99.771333, note:""},
-	{file:"jtl3nztel5z5inv/2013-06-24%2006.45.40.jpg", dt:"Monday, June 24, 6:45 AM", lat:36.136833, lon:-99.813167, note:""},
-	{file:"vovjx2md1z1d51v/2013-06-24%2007.16.15%20HDR.jpg", dt:"Monday, June 24, 7:16 AM", lat:36.136833, lon:-99.847667, note:""},
-	{file:"vduvqgxjkqi6216/2013-06-24%2008.11.46.jpg", dt:"Monday, June 24, 8:11 AM", lat:36.130167, lon:-100.003167, note:""},
-	{file:"39sjdx6p5lgjhdd/2013-06-24%2008.53.58.jpg", dt:"Monday, June 24, 8:53 AM", lat:36.172000, lon:-100.153333, note:""},
-	{file:"njsackiimqbn3uq/2013-06-24%2010.41.18.jpg", dt:"Monday, June 24, 10:41 AM", lat:36.200000, lon:-100.444167, note:""},
-	{file:"w7oq7bvtu5e778k/2013-06-24%2014.10.23%20HDR.jpg", dt:"Monday, June 24, 2:10 PM", lat:36.188000, lon:-100.820500, note:""},
-	{file:"glheyozledltn0q/2013-06-25%2009.21.09.jpg", dt:"Tuesday, June 25, 9:21 AM", lat:36.321500, lon:-101.647333, note:""},
-	{file:"19dthtldh2btfwj/2013-06-25%2013.45.20.jpg", dt:"Tuesday, June 25, 1:45 PM", lat:36.234000, lon:-102.239167, note:""},
-	{file:"v42l8ntgiixcpve/2013-06-26%2006.42.05.jpg", dt:"Wednesday, June 26, 6:42 AM", lat:36.090500, lon:-102.558667, note:""},
-	{file:"v42j61txatz4tgk/2013-06-26%2008.22.38.jpg", dt:"Wednesday, June 26, 8:22 AM", lat:36.275167, lon:-102.862333, note:""},
-	{file:"au83c15y5ua3uio/2013-06-26%2010.53.10.jpg", dt:"Wednesday, June 26, 10:53 AM", lat:36.390500, lon:-103.044500, note:""},
-	{file:"m2uwgf4agecn4s7/2013-06-26%2011.17.39.jpg", dt:"Wednesday, June 26, 11:17 AM", lat:36.413833, lon:-103.126667, note:""},
-	{file:"meng6jd6666tpfr/2013-06-26%2011.53.41.jpg", dt:"Wednesday, June 26, 11:53 AM", lat:36.468833, lon:-103.228333, note:""},
-	{file:"p6jlmbl2k4ucfo3/2013-06-26%2014.06.57.jpg", dt:"Wednesday, June 26, 2:06 PM", lat:36.477833, lon:-103.341500, note:""},
-	{file:"z5gnf4ejp4jrv15/2013-06-26%2014.13.36.jpg", dt:"Wednesday, June 26, 2:13 PM", lat:36.661667, lon:-103.765667, note:""},
-	{file:"ouxzhdukaujgtho/2013-06-26%2019.53.05.jpg", dt:"Wednesday, June 26, 7:53 PM", lat:36.762167, lon:-103.838833, note:""},
-	{file:"plioh63zuhqa1eu/2013-06-27%2006.41.59.jpg", dt:"Thursday, June 27, 6:41 AM", lat:36.713500, lon:-103.854833, note:""},
-	{file:"etoy7909v6dtods/2013-06-27%2007.49.46.jpg", dt:"Thursday, June 27, 7:49 AM", lat:35.251500, lon:-106.478167, note:""},
-	{file:"46f0snd5ul918gc/2013-06-27%2009.46.28.jpg", dt:"Thursday, June 27, 9:46 AM", lat:37.170833, lon:-103.882667, note:""},
-	{file:"8selhgl33f5z7cf/2013-06-27%2009.46.51.jpg", dt:"Thursday, June 27, 9:46 AM", lat:37.170500, lon:-103.883167, note:""},
-	{file:"8rw2mlwscptr6i8/2013-06-29%2007.51.48.jpg", dt:"Saturday, June 29, 7:51 AM", lat:37.123333, lon:-104.737500, note:""},
-	{file:"z2w92tmhvublgby/2013-06-29%2008.53.17.jpg", dt:"Saturday, June 29, 8:53 AM", lat:37.1582, lon:-104.9318, note:""},
-	{file:"x13zek0ynrvxhm4/2013-06-29%2009.37.26.jpg", dt:"Saturday, June 29, 9:37 AM", lat:37.149000, lon:-105.030333, note:""},
-	{file:"1blx2aqe3rj4svl/2013-06-29%2013.03.27.jpg", dt:"Saturday, June 29, 1:03 PM", lat:37.311833, lon:-105.060333, note:""},
-	{file:"gki2zd12b9spogk/2013-06-29%2011.05.56.jpg", dt:"Saturday, June 29, 11:05 AM", lat:37.219667, lon:-105.046167, note:""},
-	{file:"6crhvfbv2zbm7ag/2013-06-29%2014.22.09.jpg", dt:"Saturday, June 29, 2:22 PM", lat:37.524500, lon:-104.999167, note:""},
-	{file:"cpnnvjg8zhuygoo/2013-06-29%2014.54.18.jpg", dt:"Saturday, June 29, 2:54 PM", lat:37.585333, lon:-104.878833, note:""},
-	{file:"6ig25wz73o7ttbu/2013-06-30%2006.56.39.jpg", dt:"Sunday, June 30, 6:56 AM", lat:37.7094, lon:-104.9115, note:""},
-	{file:"uq21uvjsvzz1z54/2013-06-30%2019.32.16.jpg", dt:"Sunday, June 30, 7:32 PM", lat:38.275333, lon:-104.609333, note:""},
-	{file:"ast3v1po4b22ddk/2013-06-30%2010.44.46.jpg", dt:"Sunday, June 30, 10:44 AM", lat:37.937667, lon:-105.327000, note:""},
-	{file:"gw76xrjpww99l85/2013-06-30%2012.02.18.jpg", dt:"Sunday, June 30, 12:02 PM", lat:38.147667, lon:-105.365333, note:""},
-	{file:"62mdu5pb2t0sx5m/2013-06-30%2012.18.07.jpg", dt:"Sunday, June 30, 12:18 PM", lat:38.141167, lon:-105.342833, note:""},
-	{file:"zm4yb57ocehsaht/2013-06-30%2012.36.36.jpg", dt:"Sunday, June 30, 12:36 PM", lat:38.158667, lon:-105.301500, note:""},
-	{file:"vydr2d2zbbidnpk/2013-06-30%2013.18.47.jpg", dt:"Sunday, June 30, 1:18 PM", lat:38.198667, lon:-105.101500, note:""},
-	{file:"y8m8s9dq7ii2jwl/2013-06-30%2013.18.51.jpg", dt:"Sunday, June 30, 1:18 PM", lat:38.198667, lon:-105.101833, note:""},
-	{file:"24rl39ckz6rkfng/2013-06-30%2016.19.01.jpg", dt:"Sunday, June 30, 4:19 PM", lat:38.275833, lon:-104.609167, note:""},
-	{file:"7qyjrupk5ftn6tw/2013-07-01%2012.52.14.jpg", dt:"Monday, July 1, 12:52 PM", lat:38.940500, lon:-104.765667, note:""},
-	{file:"l4vblqim6oyl040/2013-07-05%2014.27.12.jpg", dt:"Friday, July 5, 2:27 PM", lat:38.944833, lon:-104.710500, note:""},
-	{file:"mbg2odz5cw795v8/2013-07-08%2020.23.35.jpg", dt:"Monday, July 8, 8:23 PM", lat:38.941667, lon:-104.778000, note:""},
-	{file:"bk63b60guvvqnq8/2013-07-09%2008.45.20.jpg", dt:"Tuesday, July 9, 8:45 AM", lat:38.865000, lon:-104.897333, note:""},
-	{file:"h48xpn6n5tsynrj/2013-07-12%2016.01.51.jpg", dt:"Friday, July 12, 4:01 PM", lat:39.549833, lon:-107.610333, note:""},
-	{file:"o4grif8edmbeey7/2013-07-13%2010.32.49.jpg", dt:"Saturday, July 13, 10:32 AM", lat:39.549833, lon:-107.647167, note:""},
-	{file:"ucnu50o9f76ow7w/2013-07-15%2008.00.29.jpg", dt:"Monday, July 15, 8:00 AM", lat:40.181667, lon:-108.455333, note:""},
-	{file:"5afaviqpwaplgkl/2013-07-15%2010.26.22.jpg", dt:"Monday, July 15, 10:26 AM", lat:40.097333, lon:-108.830833, note:""},
-	{file:"dvg258nh7nqewki/2013-07-15%2011.45.51.jpg", dt:"Monday, July 15, 11:45 AM", lat:40.273500, lon:-109.051000, note:""},
-	{file:"b9lnfxodvr7f1zr/2013-07-15%2012.33.53.jpg", dt:"Monday, July 15, 12:33 PM", lat:40.315667, lon:-109.230333, note:""},
-	{file:"riswapa1azop9lm/2013-07-15%2012.56.30.jpg", dt:"Monday, July 15, 12:56 PM", lat:40.320333, lon:-109.241667, note:""},
-	{file:"7x0sk1iuidttbrh/2013-07-16%2020.30.06.jpg", dt:"Tuesday, July 16, 8:30 PM", lat:40.191833, lon:-110.457333, note:""},
-	{file:"f81tvnfennelz81/2013-07-17%2006.02.29.jpg", dt:"Wednesday, July 17, 6:02 AM", lat:40.191833, lon:-110.457333, note:""},
-	{file:"uhgqaiulfdd8knc/2013-07-17%2011.26.38.jpg", dt:"Wednesday, July 17, 11:26 AM", lat:40.225667, lon:-111.110833, note:""},
-	{file:"b1l757dz5cmfodf/2013-07-18%2009.04.26.jpg", dt:"Thursday, July 18, 9:04 AM", lat:40.236167, lon:-111.665500, note:""},
-	{file:"knsw6kyktcm0zza/2013-07-19%2010.08.28.jpg", dt:"Friday, July 19, 10:08 AM", lat:40.476500, lon:-111.822500, note:""},
-	{file:"fhxpfu1qclk6xhq/2013-07-19%2010.19.10.jpg", dt:"Friday, July 19, 10:19 AM", lat:40.483000, lon:-111.835167, note:""},
-	{file:"mvkilnj4gk5a5np/2013-07-22%2006.58.12.jpg", dt:"Monday, July 22, 6:58 AM", lat:41.967500, lon:-112.714000, note:""},
-	{file:"hkibhcdkuwnu3b8/2013-07-22%2021.09.56.jpg", dt:"Monday, July 22, 9:09 PM", lat:42.539333, lon:-113.786000, note:""},
-	{file:"y4t5zm5lmyaaomz/2013-07-23%2008.55.54.jpg", dt:"Tuesday, July 23, 8:55 AM", lat:42.560500, lon:-113.805667, note:""},
-	{file:"gdxrmn3lyuo6ora/2013-07-23%2015.41.58.jpg", dt:"Tuesday, July 23, 3:41 PM", lat:42.598000, lon:-114.477333, note:""},
-	{file:"4x4mhm4buk3l3ci/2013-07-25%2006.53.26.jpg", dt:"Thursday, July 25, 6:53 AM", lat:42.593833, lon:-114.401833, note:""},
-	{file:"a3vbiq2blslbqqm/2013-07-25%2010.28.29.jpg", dt:"Thursday, July 25, 10:28 AM", lat:42.885833, lon:-114.914833, note:""},
-	{file:"tg3qudpr6nsflee/2013-07-25%2011.10.32 HDR.jpg", dt:"Thursday, July 25, 11:10 AM", lat:42.954500, lon:-115.043333, note:""},
-	{file:"2v7zer5te32hsju/2013-07-25%2011.34.07 HDR.jpg", dt:"Thursday, July 25, 11:34 AM", lat:42.975000, lon:-115.159000, note:""},
-	{file:"t0ygwpa3o73tz8q/2013-07-25%2013.22.48 HDR.jpg", dt:"Thursday, July 25, 1:22 PM", lat:42.998000, lon:-115.385500, note:""},
-	{file:"m3plqt0b9uzgk0w/2013-07-28%2007.04.45.jpg", dt:"Sunday, July 28, 7:04 AM", lat:44.010500, lon:-116.983167, note:""},
-	{file:"ns27qjr34m6v6kt/2013-07-28%2007.26.24.jpg", dt:"Sunday, July 28, 7:26 AM", lat:43.988833, lon:-117.069500, note:""},
-	{file:"hpwgsyba27y5xa4/2013-07-28%2009.02.30.jpg", dt:"Sunday, July 28, 9:02 AM", lat:43.899000, lon:-117.437167, note:""},
-	{file:"dkoe56erljat7a0/2013-07-28%2009.34.04.jpg", dt:"Sunday, July 28, 9:34 AM", lat:43.857167, lon:-117.601167, note:""},
-	{file:"e2fjsflrhx6c5za/2013-07-28%2010.58.04.jpg", dt:"Sunday, July 28, 10:58 AM", lat:43.778667, lon:-117.747500, note:""},
-	{file:"gqksro69decpk2e/2013-07-28%2011.26.42.jpg", dt:"Sunday, July 28, 11:26 AM", lat:43.763667, lon:-118.051167, note:""},
-	{file:"m8b832js85kk5ov/2013-07-29%2007.48.45.jpg", dt:"Monday, July 29, 7:48 AM", lat:43.784500, lon:-118.278833, note:""},
-	{file:"fkqec1stp3o2iu3/2013-07-30%2011.15.34.jpg", dt:"Tuesday, July 30, 11:15 AM", lat:43.541833, lon:-119.503667, note:""},
-	{file:"6ixifay415ukomg/2013-07-31%2007.18.57.jpg", dt:"Wednesday, July 31, 7:18 AM", lat:43.1532, lon:-119.9562, note:""},
-	{file:"fyjzyzu1le1owsx/2013-07-31%2008.09.25.jpg", dt:"Wednesday, July 31, 8:09 AM", lat:42.966500, lon:-119.994833, note:""},
-	{file:"1pbekz016c592fi/2013-07-31%2009.10.20.jpg", dt:"Wednesday, July 31, 9:10 AM", lat:42.8338, lon:-120.0291, note:""},
-	{file:"ixbvktl5e2tthdy/2013-07-31%2009.59.30.jpg", dt:"Wednesday, July 31, 9:59 AM", lat:42.7933, lon:-120.0830, note:""},
-	{file:"k2c9m0eknf9lp25/2013-07-31%2010.23.13.jpg", dt:"Wednesday, July 31, 10:23 AM", lat:42.7080, lon:-120.1358, note:""},
-	{file:"piqbg2nefoiggi4/2013-07-31%2010.28.50.jpg", dt:"Wednesday, July 31, 10:28 AM", lat:42.6922, lon:-120.1512, note:""},
-	{file:"zzgjv7mv85rctxt/2013-07-31%2011.00.56.jpg", dt:"Wednesday, July 31, 11:00 AM", lat:42.6070, lon:-120.1850, note:""},
-	{file:"hl0gu6gdgj3ppwe/2013-08-01%2008.08.08.jpg", dt:"Thursday, August 1, 8:08 AM", lat:42.187167, lon:-120.350167, note:""},
-	{file:"tr9c8weqh0uuzjc/2013-08-01%2009.27.20.jpg", dt:"Thursday, August 1, 9:27 AM", lat:41.998500, lon:-120.298000, note:""},
-	{file:"6q25hynb2z2n9iw/2013-08-01%2009.58.09.jpg", dt:"Thursday, August 1, 9:58 AM", lat:41.993000, lon:-120.298167, note:""},
-	{file:"omx4upbt7vhpr9l/2013-08-01%2010.56.27.jpg", dt:"Thursday, August 1, 10:56 AM", lat:41.867167, lon:-120.348833, note:""},
-	{file:"uj4mc4txn4ebspq/2013-08-01%2011.03.52.jpg", dt:"Thursday, August 1, 11:03 AM", lat:41.920333, lon:-120.350000, note:""},
-	{file:"frca91dyxd7zk4g/2013-08-01%2011.37.53.jpg", dt:"Thursday, August 1, 11:37 AM", lat:41.788333, lon:-120.370500, note:""},
-	{file:"i7a7um5fn0zcd1h/2013-08-02%2006.15.37.jpg", dt:"Friday, August 2, 6:15 AM", lat:41.484833, lon:-120.541667, note:""},
-	{file:"mxcz5ftc700dnny/2013-08-02%2013.41.02.jpg", dt:"Friday, August 2, 1:41 PM", lat:40.937833, lon:-121.450500, note:""}]
+    {
+        "dt": "Thursday, May 23, 12:54 PM",
+        "file": "2013-05-23%2012.54.48_resized.jpg",
+        "key": "AAAszOigLU4ZqphCaaP2Pz9va",
+        "lat": 32.756167,
+        "lon": -79.857167,
+        "note": "Shakedown ride."
+    },
+    {
+        "dt": "Thursday, May 23, 1:07 PM",
+        "file": "2013-05-23%2013.07.12_resized.jpg",
+        "key": "AADbqZlvpwIf10Vh23rH54qYa",
+        "lat": 32.758833,
+        "lon": -79.856667,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, May 23, 2:11 PM",
+        "file": "2013-05-23%2014.11.45_resized.jpg",
+        "key": "AAAYLiNlzIpGXZ70PhsdhOk0a",
+        "lat": 32.8025,
+        "lon": -79.912833,
+        "note": ""
+    },
+    {
+        "dt": "Friday, May 24, 1:10 PM",
+        "file": "2013-05-24%2013.10.45_resized.jpg",
+        "key": "AABdkxy1WLaZB5glkWkSCkJNa",
+        "lat": 32.890167,
+        "lon": -80.024333,
+        "note": ""
+    },
+    {
+        "dt": "Friday, May 24, 8:25 PM",
+        "file": "2013-05-24%2020.25.22_resized.jpg",
+        "key": "AADRRHh7GegPP6TumnCgrvnZa",
+        "lat": 32.790833,
+        "lon": -79.9615,
+        "note": "After our Build day on Thursday we went to go see a minor league Charleston Riverdogs game. Marcus led us all in cheering."
+    },
+    {
+        "dt": "Saturday, May 25, 7:32 AM",
+        "file": "2013-05-25%2007.32.05_resized.jpg",
+        "key": "AAB6GSnzvmHfpfyGjPlwfWHTa",
+        "lat": 32.784833,
+        "lon": -79.933,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, May 25, 8:42 AM",
+        "file": "2013-05-25%2008.42.24_resized.jpg",
+        "key": "AABwJGeJ1BMyf-d69QlYQhLSa",
+        "lat": 32.773,
+        "lon": -79.927333,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, May 25, 11:08 AM",
+        "file": "2013-05-25%2011.08.11_resized.jpg",
+        "key": "AAAdz62hrfFZsbqk_2rhnDCta",
+        "lat": 32.972,
+        "lon": -80.005,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, May 25, 12:37 PM",
+        "file": "2013-05-25%2012.37.21_resized.jpg",
+        "key": "AACyyM9IzZLH8eAEGdHq3pOXa",
+        "lat": 33.059667,
+        "lon": -80.034667,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, May 25, 1:22 PM",
+        "file": "2013-05-25%2013.22.10_resized.jpg",
+        "key": "AAARlaFCkuRs29GdBMvfDLc1a",
+        "lat": 33.120333,
+        "lon": -80.018667,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, May 25, 7:46 PM",
+        "file": "2013-05-25%2019.46.06_resized.jpg",
+        "key": "AADvKpHmjqNNJszuinGNOFMaa",
+        "lat": 33.185667,
+        "lon": -80.000833,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, May 26, 7:46 AM",
+        "file": "2013-05-26%2007.46.23_resized.jpg",
+        "key": "AACiJT4BuxJoy6RGBY1RQszZa",
+        "lat": 33.225833,
+        "lon": -80.038833,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, May 26, 10:55 AM",
+        "file": "2013-05-26%2010.55.53_resized.jpg",
+        "key": "AAAB5OmIv1o-I_aVqqbZI7Ioa",
+        "lat": 33.4115,
+        "lon": -79.981,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, May 26, 11:41 AM",
+        "file": "2013-05-26%2011.41.59_resized.jpg",
+        "key": "AADOm9xY6Q1luuhRWjH9kW_0a",
+        "lat": 33.438333,
+        "lon": -79.984667,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, May 26, 2:13 PM",
+        "file": "2013-05-26%2014.13.45_resized.jpg",
+        "key": "AAAUJi3iccirEJdnTcnIxJsma",
+        "lat": 33.695333,
+        "lon": -80.210667,
+        "note": ""
+    },
+    {
+        "dt": "Monday, May 27, 3:34 PM",
+        "file": "2013-05-27%2015.34.52_resized.jpg",
+        "key": "AADaAb7360aILGJFmCaPdUs7a",
+        "lat": 33.893833,
+        "lon": -80.316667,
+        "note": ""
+    },
+    {
+        "dt": "Tuesday, May 28, 8:10 AM",
+        "file": "2013-05-28%2008.10.17_resized.jpg",
+        "key": "AADwUVrbFKqz_b1byJ-NFJa9a",
+        "lat": 33.917,
+        "lon": -80.368833,
+        "note": ""
+    },
+    {
+        "dt": "Tuesday, May 28, 8:38 PM",
+        "file": "2013-05-28%2020.38.29_resized.jpg",
+        "key": "AAAxx6Z2Lys6m19Pt-Fe3SiXa",
+        "lat": 34.001167,
+        "lon": -81.033667,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, May 29, 8:57 AM",
+        "file": "2013-05-29%2008.57.16_resized.jpg",
+        "key": "AAAnIotwTOy8sO14htGA7SBza",
+        "lat": 33.994833,
+        "lon": -81.055167,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, May 29, 10:20 AM",
+        "file": "2013-05-29%2010.20.31_resized.jpg",
+        "key": "AAC_v2mwWI2hCscp3cIyip6pa",
+        "lat": 34.0375,
+        "lon": -81.2185,
+        "note": ""
+    },
+    {
+        "dt": "Friday, May 31, 8:12 PM",
+        "file": "2013-05-31%2020.12.37_resized.jpg",
+        "key": "AACe967OjKwkCPpf9wvmhLsVa",
+        "lat": 34.778333,
+        "lon": -82.266167,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, June 1, 10:33 AM",
+        "file": "2013-06-01%2010.33.50_resized.jpg",
+        "key": "AAC2jLyuN25VD0G20QOwrxFga",
+        "lat": 34.641333,
+        "lon": -82.5435,
+        "note": ""
+    },
+    {
+        "dt": "Monday, June 3, 9:08 AM",
+        "file": "2013-06-03%2009.08.15_resized.jpg",
+        "key": "AABiTGv-3-QQu_VvDAmjMuQ1a",
+        "lat": 34.000667,
+        "lon": -83.543833,
+        "note": ""
+    },
+    {
+        "dt": "Monday, June 3, 9:51 AM",
+        "file": "2013-06-03%2009.51.42_resized.jpg",
+        "key": "AAAVvQQdU-2ChH8t5lcmisvQa",
+        "lat": 33.986833,
+        "lon": -83.682833,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 5, 10:31 AM",
+        "file": "2013-06-05%2010.31.28_resized.jpg",
+        "key": "AACGzh5t5fdejp4izv4rUMhPa",
+        "lat": 34.3885,
+        "lon": -85.62,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 5, 10:35 AM",
+        "file": "2013-06-05%2010.35.01_resized.jpg",
+        "key": "AABsy7gUd3puGXN1sp3KSudEa",
+        "lat": 34.387833,
+        "lon": -85.62,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 5, 12:53 PM",
+        "file": "2013-06-05%2012.53.29_resized.jpg",
+        "key": "AACYkh8QZ7a9ZUZNV4y3jQKfa",
+        "lat": 34.495167,
+        "lon": -85.746833,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 5, 1:02 PM",
+        "file": "2013-06-05%2013.02.45_resized.jpg",
+        "key": "AADun-IyBVHQ_LYFIW08KZ6Za",
+        "lat": 34.495,
+        "lon": -85.747,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, June 6, 10:32 AM",
+        "file": "2013-06-06%2010.32.14_resized.jpg",
+        "key": "AACbxteimr134ppCnmw3YBEKa",
+        "lat": 34.564,
+        "lon": -86.5475,
+        "note": ""
+    },
+    {
+        "dt": "Tuesday, June 11, 12:26 PM",
+        "file": "2013-06-11%2012.26.46_resized.jpg",
+        "key": "AAB1lQZs9C5L0-noqLmxnzIca",
+        "lat": 34.278,
+        "lon": -89.3905,
+        "note": ""
+    },
+    {
+        "dt": "Tuesday, June 11, 3:01 PM",
+        "file": "2013-06-11%2015.01.35_resized.jpg",
+        "key": "AABfVJd182bJ5szoLaFvg-EBa",
+        "lat": 34.370333,
+        "lon": -89.513333,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 12, 7:17 AM",
+        "file": "2013-06-12%2007.17.42_resized.jpg",
+        "key": "AADBiqfPtOgCzHXURyqpA0Foa",
+        "lat": 34.364833,
+        "lon": -89.533833,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 12, 2:15 PM",
+        "file": "2013-06-12%2014.15.22_resized.jpg",
+        "key": "AABC5xnE9k9qtLEGSS53MdESa",
+        "lat": 34.204667,
+        "lon": -90.506333,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, June 13, 9:45 AM",
+        "file": "2013-06-13%2009.45.21_resized.jpg",
+        "key": "AAAZqDLHdaSEYPq_wOZqSexCa",
+        "lat": 34.554667,
+        "lon": -90.662167,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, June 13, 7:08 PM",
+        "file": "2013-06-13%2019.08.30_resized.jpg",
+        "key": "AACgdpbGmNwKyiE3Pu-zT8LEa",
+        "lat": 34.479333,
+        "lon": -91.5545,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, June 13, 7:45 PM",
+        "file": "2013-06-13%2019.45.34_resized.jpg",
+        "key": "AADpYGsizO2I-C_wu7svmxnra",
+        "lat": 34.476,
+        "lon": -91.557667,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, June 13, 7:45 PM",
+        "file": "2013-06-13%2019.45.37_resized.jpg",
+        "key": "AAAzjdNCdrdhTWDekmfOeg9Sa",
+        "lat": 34.476,
+        "lon": -91.557833,
+        "note": ""
+    },
+    {
+        "dt": "Friday, June 14, 8:12 PM",
+        "file": "2013-06-14%2020.12.52_resized.jpg",
+        "key": "AAArA5EGnLduKqnYOTAW9MQDa",
+        "lat": 34.772167,
+        "lon": -92.300167,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, June 16, 8:35 AM",
+        "file": "2013-06-16%2008.35.19_resized.jpg",
+        "key": "AABSq6s0NaFZFtOjUXImW4f4a",
+        "lat": 34.926333,
+        "lon": -92.563833,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, June 16, 1:51 PM",
+        "file": "2013-06-16%2013.51.34_resized.jpg",
+        "key": "AACBXIHIxahkBzTVT-YjKqCWa",
+        "lat": 35.115,
+        "lon": -92.951,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, June 22, 9:25 AM",
+        "file": "2013-06-22%2009.25.17_resized.jpg",
+        "key": "AAC5TYn5fh7FKOHlcdPU8RNYa",
+        "lat": 35.683667,
+        "lon": -97.923667,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, June 23, 9:42 AM",
+        "file": "2013-06-23%2009.42.09_resized.jpg",
+        "key": "AAANJl7Vo7wCWEW2-_w_7A3Fa",
+        "lat": 36.144167,
+        "lon": -99.033167,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, June 23, 11:03 AM",
+        "file": "2013-06-23%2011.03.44_resized.jpg",
+        "key": "AADgPw4ni4vdnjfwgjkBk3eDa",
+        "lat": 36.15,
+        "lon": -99.297833,
+        "note": ""
+    },
+    {
+        "dt": "Monday, June 24, 6:16 AM",
+        "file": "2013-06-24%2006.16.53_resized.jpg",
+        "key": "AAAwUdcPfqdRSxTbbbhs5gYTa",
+        "lat": 36.133667,
+        "lon": -99.771333,
+        "note": ""
+    },
+    {
+        "dt": "Monday, June 24, 6:45 AM",
+        "file": "2013-06-24%2006.45.40_resized.jpg",
+        "key": "AABRML3EHdzH-tGEJXIUK2CIa",
+        "lat": 36.136833,
+        "lon": -99.813167,
+        "note": ""
+    },
+    {
+        "dt": "Monday, June 24, 7:16 AM",
+        "file": "2013-06-24%2007.16.15%20HDR_resized.jpg",
+        "key": "AAA5igwkViN0IusnTNZwE4ZEa",
+        "lat": 36.136833,
+        "lon": -99.847667,
+        "note": ""
+    },
+    {
+        "dt": "Monday, June 24, 8:11 AM",
+        "file": "2013-06-24%2008.11.46_resized.jpg",
+        "key": "AACHNWw4HgbyMTPnNMDlus3Ea",
+        "lat": 36.130167,
+        "lon": -100.003167,
+        "note": ""
+    },
+    {
+        "dt": "Monday, June 24, 8:53 AM",
+        "file": "2013-06-24%2008.53.58_resized.jpg",
+        "key": "AACyhfzIA7Pa8rZmGi-sNM5ta",
+        "lat": 36.172,
+        "lon": -100.153333,
+        "note": ""
+    },
+    {
+        "dt": "Monday, June 24, 10:41 AM",
+        "file": "2013-06-24%2010.41.18_resized.jpg",
+        "key": "AABmfizKPBHW1hXSU_7oTqnla",
+        "lat": 36.2,
+        "lon": -100.444167,
+        "note": ""
+    },
+    {
+        "dt": "Monday, June 24, 2:10 PM",
+        "file": "2013-06-24%2014.10.23%20HDR_resized.jpg",
+        "key": "AADIfd_puVPdmHrji18eJu7aa",
+        "lat": 36.188,
+        "lon": -100.8205,
+        "note": ""
+    },
+    {
+        "dt": "Tuesday, June 25, 9:21 AM",
+        "file": "2013-06-25%2009.21.09_resized.jpg",
+        "key": "AADJmIIQT9b7J_XdFJIarOopa",
+        "lat": 36.3215,
+        "lon": -101.647333,
+        "note": ""
+    },
+    {
+        "dt": "Tuesday, June 25, 1:45 PM",
+        "file": "2013-06-25%2013.45.20_resized.jpg",
+        "key": "AAAlYLsh07JdRcyFj7_tUJSta",
+        "lat": 36.234,
+        "lon": -102.239167,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 26, 6:42 AM",
+        "file": "2013-06-26%2006.42.05_resized.jpg",
+        "key": "AAAqGVlRnBxk_HEWF3YeUDMUa",
+        "lat": 36.0905,
+        "lon": -102.558667,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 26, 8:22 AM",
+        "file": "2013-06-26%2008.22.38_resized.jpg",
+        "key": "AADhcQ_VHIWWxDr4JlQNj9JEa",
+        "lat": 36.275167,
+        "lon": -102.862333,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 26, 10:53 AM",
+        "file": "2013-06-26%2010.53.10_resized.jpg",
+        "key": "AAAScgy4REjbD97ZcGChuNB5a",
+        "lat": 36.3905,
+        "lon": -103.0445,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 26, 11:17 AM",
+        "file": "2013-06-26%2011.17.39_resized.jpg",
+        "key": "AADE1si_kEgynR8WawRKRlJ6a",
+        "lat": 36.413833,
+        "lon": -103.126667,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 26, 11:53 AM",
+        "file": "2013-06-26%2011.53.41_resized.jpg",
+        "key": "AACW3e5viY-stV9Qy9IBnWAwa",
+        "lat": 36.468833,
+        "lon": -103.228333,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 26, 2:06 PM",
+        "file": "2013-06-26%2014.06.57_resized.jpg",
+        "key": "AAAdNy0JFD6kVpsgkJVBC8xSa",
+        "lat": 36.477833,
+        "lon": -103.3415,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 26, 2:13 PM",
+        "file": "2013-06-26%2014.13.36_resized.jpg",
+        "key": "AACuCgAASG16LLyYMdAbbvzwa",
+        "lat": 36.661667,
+        "lon": -103.765667,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, June 26, 7:53 PM",
+        "file": "2013-06-26%2019.53.05_resized.jpg",
+        "key": "AAADuHf-9wQiFy7KrrGtMZ2ba",
+        "lat": 36.762167,
+        "lon": -103.838833,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, June 27, 6:41 AM",
+        "file": "2013-06-27%2006.41.59_resized.jpg",
+        "key": "AABz4RIbKVFo33WgSF47p2Lya",
+        "lat": 36.7135,
+        "lon": -103.854833,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, June 27, 7:49 AM",
+        "file": "2013-06-27%2007.49.46_resized.jpg",
+        "key": "AACuxZM4wuVMv1m6BHmRYhWla",
+        "lat": 35.2515,
+        "lon": -106.478167,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, June 27, 9:46 AM",
+        "file": "2013-06-27%2009.46.28_resized.jpg",
+        "key": "AACdD3vODViL2pk758wShAKWa",
+        "lat": 37.170833,
+        "lon": -103.882667,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, June 27, 9:46 AM",
+        "file": "2013-06-27%2009.46.51_resized.jpg",
+        "key": "AACSxUJKn1UIBXDv8_NL-3AGa",
+        "lat": 37.1705,
+        "lon": -103.883167,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, June 29, 7:51 AM",
+        "file": "2013-06-29%2007.51.48_resized.jpg",
+        "key": "AABXeZxSdiUDn972CkRaNf1oa",
+        "lat": 37.123333,
+        "lon": -104.7375,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, June 29, 8:53 AM",
+        "file": "2013-06-29%2008.53.17_resized.jpg",
+        "key": "AABcpOdFKzPCg_N0eanb3huva",
+        "lat": 37.1582,
+        "lon": -104.9318,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, June 29, 9:37 AM",
+        "file": "2013-06-29%2009.37.26_resized.jpg",
+        "key": "AACxMEk4QbeeeztnZBfnrm3Pa",
+        "lat": 37.149,
+        "lon": -105.030333,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, June 29, 1:03 PM",
+        "file": "2013-06-29%2013.03.27_resized.jpg",
+        "key": "AACUR68JgOznx7aOEd33gA87a",
+        "lat": 37.311833,
+        "lon": -105.060333,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, June 29, 11:05 AM",
+        "file": "2013-06-29%2011.05.56_resized.jpg",
+        "key": "AADAaE4ojnDsJueZBKVodVcYa",
+        "lat": 37.219667,
+        "lon": -105.046167,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, June 29, 2:22 PM",
+        "file": "2013-06-29%2014.22.09_resized.jpg",
+        "key": "AAB6jFrHW-rr1BIv6Te3pqKBa",
+        "lat": 37.5245,
+        "lon": -104.999167,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, June 29, 2:54 PM",
+        "file": "2013-06-29%2014.54.18_resized.jpg",
+        "key": "AADGSdJAwVeRkMNVQLO0H47Aa",
+        "lat": 37.585333,
+        "lon": -104.878833,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, June 30, 6:56 AM",
+        "file": "2013-06-30%2006.56.39_resized.jpg",
+        "key": "AAAC04Y-4Bm24jEm_S3lE2UEa",
+        "lat": 37.7094,
+        "lon": -104.9115,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, June 30, 7:32 PM",
+        "file": "2013-06-30%2019.32.16_resized.jpg",
+        "key": "AAA_g56kqF7GGtZC5vEXJy38a",
+        "lat": 38.275333,
+        "lon": -104.609333,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, June 30, 10:44 AM",
+        "file": "2013-06-30%2010.44.46_resized.jpg",
+        "key": "AADRHxTomdNLAKzzdxGH9xx9a",
+        "lat": 37.937667,
+        "lon": -105.327,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, June 30, 12:02 PM",
+        "file": "2013-06-30%2012.02.18_resized.jpg",
+        "key": "AABiIC6CQy7eyebInTWNBPyQa",
+        "lat": 38.147667,
+        "lon": -105.365333,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, June 30, 12:18 PM",
+        "file": "2013-06-30%2012.18.07_resized.jpg",
+        "key": "AACJK69UG2Z2I82EPSmKN_1ea",
+        "lat": 38.141167,
+        "lon": -105.342833,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, June 30, 12:36 PM",
+        "file": "2013-06-30%2012.36.36_resized.jpg",
+        "key": "AAD3lwv2gMovgvfpMOb_ymWwa",
+        "lat": 38.158667,
+        "lon": -105.3015,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, June 30, 1:18 PM",
+        "file": "2013-06-30%2013.18.47_resized.jpg",
+        "key": "AAA3ESn0_1awWRg3a8k7MD5Ea",
+        "lat": 38.198667,
+        "lon": -105.1015,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, June 30, 1:18 PM",
+        "file": "2013-06-30%2013.18.51_resized.jpg",
+        "key": "AACDU6dy3y_wcKwsiaHnb7-ua",
+        "lat": 38.198667,
+        "lon": -105.101833,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, June 30, 4:19 PM",
+        "file": "2013-06-30%2016.19.01_resized.jpg",
+        "key": "AADBw5ioL-TYgAV17sRDOOGpa",
+        "lat": 38.275833,
+        "lon": -104.609167,
+        "note": ""
+    },
+    {
+        "dt": "Monday, July 1, 12:52 PM",
+        "file": "2013-07-01%2012.52.14_resized.jpg",
+        "key": "AAC1FX3eBbHu6IeL3OM4aDc_a",
+        "lat": 38.9405,
+        "lon": -104.765667,
+        "note": ""
+    },
+    {
+        "dt": "Friday, July 5, 2:27 PM",
+        "file": "2013-07-05%2014.27.12_resized.jpg",
+        "key": "AAAMo9Nm9iigZeo5HvxuGK0Aa",
+        "lat": 38.944833,
+        "lon": -104.7105,
+        "note": ""
+    },
+    {
+        "dt": "Monday, July 8, 8:23 PM",
+        "file": "2013-07-08%2020.23.35_resized.jpg",
+        "key": "AAAY4AeqIWq5pQixxWaxSRj0a",
+        "lat": 38.941667,
+        "lon": -104.778,
+        "note": ""
+    },
+    {
+        "dt": "Tuesday, July 9, 8:45 AM",
+        "file": "2013-07-09%2008.45.20_resized.jpg",
+        "key": "AAB3C-QoK_0-Ea_9iUX55Hc3a",
+        "lat": 38.865,
+        "lon": -104.897333,
+        "note": ""
+    },
+    {
+        "dt": "Friday, July 12, 4:01 PM",
+        "file": "2013-07-12%2016.01.51_resized.jpg",
+        "key": "AABg4er7zFXUWO5TgQ5bxTLfa",
+        "lat": 39.549833,
+        "lon": -107.610333,
+        "note": ""
+    },
+    {
+        "dt": "Saturday, July 13, 10:32 AM",
+        "file": "2013-07-13%2010.32.49_resized.jpg",
+        "key": "AADQZH601PiQFSpBc0CCGCkma",
+        "lat": 39.549833,
+        "lon": -107.647167,
+        "note": ""
+    },
+    {
+        "dt": "Monday, July 15, 8:00 AM",
+        "file": "2013-07-15%2008.00.29_resized.jpg",
+        "key": "AAB6021XvgRUIf2loRP8S2Nqa",
+        "lat": 40.181667,
+        "lon": -108.455333,
+        "note": ""
+    },
+    {
+        "dt": "Monday, July 15, 10:26 AM",
+        "file": "2013-07-15%2010.26.22_resized.jpg",
+        "key": "AADxV90WNtKhgGFlr0Ww60U9a",
+        "lat": 40.097333,
+        "lon": -108.830833,
+        "note": ""
+    },
+    {
+        "dt": "Monday, July 15, 11:45 AM",
+        "file": "2013-07-15%2011.45.51_resized.jpg",
+        "key": "AACW41IZ3hmFX_E1YB3ysOZsa",
+        "lat": 40.2735,
+        "lon": -109.051,
+        "note": ""
+    },
+    {
+        "dt": "Monday, July 15, 12:33 PM",
+        "file": "2013-07-15%2012.33.53_resized.jpg",
+        "key": "AABMgaiH42oF-R6ao0tIQwyea",
+        "lat": 40.315667,
+        "lon": -109.230333,
+        "note": ""
+    },
+    {
+        "dt": "Monday, July 15, 12:56 PM",
+        "file": "2013-07-15%2012.56.30_resized.jpg",
+        "key": "AADKL5Y_JFSZ2YcBmATgg4oQa",
+        "lat": 40.320333,
+        "lon": -109.241667,
+        "note": ""
+    },
+    {
+        "dt": "Tuesday, July 16, 8:30 PM",
+        "file": "2013-07-16%2020.30.06_resized.jpg",
+        "key": "AACxv5z4OW96v2ZxAlWY4Kg0a",
+        "lat": 40.191833,
+        "lon": -110.457333,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, July 17, 6:02 AM",
+        "file": "2013-07-17%2006.02.29_resized.jpg",
+        "key": "AAC5whJYSuJr1BInV5LJg69Va",
+        "lat": 40.191833,
+        "lon": -110.457333,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, July 17, 11:26 AM",
+        "file": "2013-07-17%2011.26.38_resized.jpg",
+        "key": "AACCXF4U-otl96IR_wS2S40Ya",
+        "lat": 40.225667,
+        "lon": -111.110833,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, July 18, 9:04 AM",
+        "file": "2013-07-18%2009.04.26_resized.jpg",
+        "key": "AAAZ6M_6yhnDbjU1DtwAmuTBa",
+        "lat": 40.236167,
+        "lon": -111.6655,
+        "note": ""
+    },
+    {
+        "dt": "Friday, July 19, 10:08 AM",
+        "file": "2013-07-19%2010.08.28_resized.jpg",
+        "key": "AAD5_AeJAaw-bicthX1A9pnfa",
+        "lat": 40.4765,
+        "lon": -111.8225,
+        "note": ""
+    },
+    {
+        "dt": "Friday, July 19, 10:19 AM",
+        "file": "2013-07-19%2010.19.10_resized.jpg",
+        "key": "AACxo3NiIHG3jlF5d1fK7hgSa",
+        "lat": 40.483,
+        "lon": -111.835167,
+        "note": ""
+    },
+    {
+        "dt": "Monday, July 22, 6:58 AM",
+        "file": "2013-07-22%2006.58.12_resized.jpg",
+        "key": "AACWwERYI9HDX2G2YOk9O0xWa",
+        "lat": 41.9675,
+        "lon": -112.714,
+        "note": ""
+    },
+    {
+        "dt": "Monday, July 22, 9:09 PM",
+        "file": "2013-07-22%2021.09.56_resized.jpg",
+        "key": "AAB5UKnFIR3k4IWo8hqnzk04a",
+        "lat": 42.539333,
+        "lon": -113.786,
+        "note": ""
+    },
+    {
+        "dt": "Tuesday, July 23, 8:55 AM",
+        "file": "2013-07-23%2008.55.54_resized.jpg",
+        "key": "AADggsAcvNrstjAhOo8LWsJga",
+        "lat": 42.5605,
+        "lon": -113.805667,
+        "note": ""
+    },
+    {
+        "dt": "Tuesday, July 23, 3:41 PM",
+        "file": "2013-07-23%2015.41.58_resized.jpg",
+        "key": "AAB_UgKWlMeb3DTF0iPCzzXHa",
+        "lat": 42.598,
+        "lon": -114.477333,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, July 25, 6:53 AM",
+        "file": "2013-07-25%2006.53.26_resized.jpg",
+        "key": "AACSbm66TCULXmhwsKS1fQM9a",
+        "lat": 42.593833,
+        "lon": -114.401833,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, July 25, 10:28 AM",
+        "file": "2013-07-25%2010.28.29_resized.jpg",
+        "key": "AAAdG0udHVlYszZ_2Up-v1rJa",
+        "lat": 42.885833,
+        "lon": -114.914833,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, July 25, 11:10 AM",
+        "file": "2013-07-25%2011.10.32%20HDR_resized.jpg",
+        "key": "AACOjKKB4UeHE80P4UXPTWj2a",
+        "lat": 42.9545,
+        "lon": -115.043333,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, July 25, 11:34 AM",
+        "file": "2013-07-25%2011.34.07%20HDR_resized.jpg",
+        "key": "AADVbcFPsAhqIrYtPOrdzyFra",
+        "lat": 42.975,
+        "lon": -115.159,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, July 25, 1:22 PM",
+        "file": "2013-07-25%2013.22.48%20HDR_resized.jpg",
+        "key": "AAAlAR895GAYhcflGGowdCgXa",
+        "lat": 42.998,
+        "lon": -115.3855,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, July 28, 7:04 AM",
+        "file": "2013-07-28%2007.04.45_resized.jpg",
+        "key": "AACtT67WLWkBwYHfvFb0IQUaa",
+        "lat": 44.0105,
+        "lon": -116.983167,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, July 28, 7:26 AM",
+        "file": "2013-07-28%2007.26.24_resized.jpg",
+        "key": "AAD1FfeVa32U6aLoBi55H-Mja",
+        "lat": 43.988833,
+        "lon": -117.0695,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, July 28, 9:02 AM",
+        "file": "2013-07-28%2009.02.30_resized.jpg",
+        "key": "AAAzEHD63oflKYEjp7LLXY9ga",
+        "lat": 43.899,
+        "lon": -117.437167,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, July 28, 9:34 AM",
+        "file": "2013-07-28%2009.34.04_resized.jpg",
+        "key": "AAD3VqzUUXZPdYWahq2-Sz6-a",
+        "lat": 43.857167,
+        "lon": -117.601167,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, July 28, 10:58 AM",
+        "file": "2013-07-28%2010.58.04_resized.jpg",
+        "key": "AAD4CnvyehKQjI3xBytKnNdua",
+        "lat": 43.778667,
+        "lon": -117.7475,
+        "note": ""
+    },
+    {
+        "dt": "Sunday, July 28, 11:26 AM",
+        "file": "2013-07-28%2011.26.42_resized.jpg",
+        "key": "AAAR9tY_oAUU3OgLKdaHiPfEa",
+        "lat": 43.763667,
+        "lon": -118.051167,
+        "note": ""
+    },
+    {
+        "dt": "Monday, July 29, 7:48 AM",
+        "file": "2013-07-29%2007.48.45_resized.jpg",
+        "key": "AABB_vZpfsFWARnyz8SoygNma",
+        "lat": 43.7845,
+        "lon": -118.278833,
+        "note": ""
+    },
+    {
+        "dt": "Tuesday, July 30, 11:15 AM",
+        "file": "2013-07-30%2011.15.34_resized.jpg",
+        "key": "AADbilSqVmexz0Kx3-gfli0Ca",
+        "lat": 43.541833,
+        "lon": -119.503667,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, July 31, 7:18 AM",
+        "file": "2013-07-31%2007.18.57_resized.jpg",
+        "key": "AABN0jHh30hToqPwvj92qvbAa",
+        "lat": 43.1532,
+        "lon": -119.9562,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, July 31, 8:09 AM",
+        "file": "2013-07-31%2008.09.25_resized.jpg",
+        "key": "AADpyKhv4_3AcfDnRKZQhlyAa",
+        "lat": 42.9665,
+        "lon": -119.994833,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, July 31, 9:10 AM",
+        "file": "2013-07-31%2009.10.20_resized.jpg",
+        "key": "AACa6JWbMRBoaNwse5M3Ynr7a",
+        "lat": 42.8338,
+        "lon": -120.0291,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, July 31, 9:59 AM",
+        "file": "2013-07-31%2009.59.30_resized.jpg",
+        "key": "AAC_URYFZ_gqTYpBmwSX6wLMa",
+        "lat": 42.7933,
+        "lon": -120.083,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, July 31, 10:23 AM",
+        "file": "2013-07-31%2010.23.13_resized.jpg",
+        "key": "AAAQWWrNBmbKRv9KazLP_wk8a",
+        "lat": 42.708,
+        "lon": -120.1358,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, July 31, 10:28 AM",
+        "file": "2013-07-31%2010.28.50_resized.jpg",
+        "key": "AAAwOJQOh0_8HOGOhElNx6oXa",
+        "lat": 42.6922,
+        "lon": -120.1512,
+        "note": ""
+    },
+    {
+        "dt": "Wednesday, July 31, 11:00 AM",
+        "file": "2013-07-31%2011.00.56_resized.jpg",
+        "key": "AAC6jI0W7kOalQ-d_tRKD4NRa",
+        "lat": 42.607,
+        "lon": -120.185,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, August 1, 8:08 AM",
+        "file": "2013-08-01%2008.08.08_resized.jpg",
+        "key": "AABUIfqeqc9dYw_fx5ZIw3Tta",
+        "lat": 42.187167,
+        "lon": -120.350167,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, August 1, 9:27 AM",
+        "file": "2013-08-01%2009.27.20_resized.jpg",
+        "key": "AAD6rfPUh-mxmxTjG_BCbPz-a",
+        "lat": 41.9985,
+        "lon": -120.298,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, August 1, 9:58 AM",
+        "file": "2013-08-01%2009.58.09_resized.jpg",
+        "key": "AADfiepeUyioLjDA5sNKO_s4a",
+        "lat": 41.993,
+        "lon": -120.298167,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, August 1, 10:56 AM",
+        "file": "2013-08-01%2010.56.27_resized.jpg",
+        "key": "AADv13ii9LrHgyEZlxJ0yzdOa",
+        "lat": 41.867167,
+        "lon": -120.348833,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, August 1, 11:03 AM",
+        "file": "2013-08-01%2011.03.52_resized.jpg",
+        "key": "AAAvbvokdUrUpLerxNEwW0w4a",
+        "lat": 41.920333,
+        "lon": -120.35,
+        "note": ""
+    },
+    {
+        "dt": "Thursday, August 1, 11:37 AM",
+        "file": "2013-08-01%2011.37.53_resized.jpg",
+        "key": "AAA8AjTIvys9XfJt3AaOTBoba",
+        "lat": 41.788333,
+        "lon": -120.3705,
+        "note": ""
+    },
+    {
+        "dt": "Friday, August 2, 6:15 AM",
+        "file": "2013-08-02%2006.15.37_resized.jpg",
+        "key": "AABkKeWFnGpynL1DZI6fYzK9a",
+        "lat": 41.484833,
+        "lon": -120.541667,
+        "note": ""
+    },
+    {
+        "dt": "Friday, August 2, 1:41 PM",
+        "file": "2013-08-02%2013.41.02_resized.jpg",
+        "key": "AABiCfIfkgc76EW_HWejsveWa",
+        "lat": 40.937833,
+        "lon": -121.4505,
+        "note": ""
+    }
+]

--- a/bikemap/javascripts/map.js
+++ b/bikemap/javascripts/map.js
@@ -62,7 +62,7 @@ function initialize() {
         google.maps.event.addListener(pic_markers[i], 'click', (function(i) {
             return function() {
               pic_windows[i].open(map,pic_markers[i]);
-              document.getElementById("photo_"+i).innerHTML = '<img src="https://dl.dropbox.com/s/'+photos[i].file+'" height=480 width=640>';
+              document.getElementById("photo_"+i).innerHTML = '<img src="https://www.dropbox.com/sh/xf5h6dw6gqdipmk/'+photos[i].key+'/'+photos[i].file+'?raw=1" height=480 width=640>';
             }
           })(i));
     }


### PR DESCRIPTION
This PR creates a "key" entry in the photos hash for the dropbox link.

There is an updated dropbox link for the new folder, so the photos should work now.

The spacing is different because the JSON file is generated by pythons `json.dumps` which has limited options for formatting.

